### PR TITLE
Issue#27

### DIFF
--- a/app/assets/stylesheets/customize.scss
+++ b/app/assets/stylesheets/customize.scss
@@ -39,3 +39,12 @@ body {
 .pagination {
   justify-content: center;
 }
+
+#error_explanation {
+  ul{
+    padding-left: 0;
+  }
+  li{
+    list-style: none;
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,15 +27,15 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to users_path, notice: "ユーザー情報を更新しました"
     else
-      redirect_to users_path, alert: "管理者は最低1人必要です"
+      render :edit
     end
   end
 
   def destroy
-    if @user.destroy
-      redirect_to users_path, notice: "ユーザーを削除しました"
-    elsif current_user.id == @user.id && current_user.admin?
+    if current_user.id == @user.id && current_user.admin?
       redirect_to users_path, alert: "管理者は他の管理者から編集・削除をしてください"
+    elsif @user.destroy
+      redirect_to users_path, notice: "ユーザーを削除しました"
     else
       redirect_to users_path, alert: "管理者は最低1人必要です"
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :logged_in?
-  before_action :ensure_admin, except: [:show]
+  before_action :ensure_admin, except: [:show, :edit]
   before_action :ensure_current_user, only: [:show, :status]
   before_action :set_users, only: [:show, :edit, :update, :destroy]
   before_action :set_date, only: [:index, :status, :show]
@@ -18,6 +18,9 @@ class UsersController < ApplicationController
   end
 
   def edit
+    if current_user.id == @user.id
+      redirect_to users_path, alert: "管理者は他の管理者から編集・削除をしてください"
+    end
   end
 
   def update
@@ -31,6 +34,8 @@ class UsersController < ApplicationController
   def destroy
     if @user.destroy
       redirect_to users_path, notice: "ユーザーを削除しました"
+    elsif current_user.id == @user.id && current_user.admin?
+      redirect_to users_path, alert: "管理者は他の管理者から編集・削除をしてください"
     else
       redirect_to users_path, alert: "管理者は最低1人必要です"
     end

--- a/app/helpers/time_cards_helper.rb
+++ b/app/helpers/time_cards_helper.rb
@@ -80,7 +80,7 @@ module TimeCardsHelper
   def set_user_chart_data
     @chart_days = TimeCard.where(year: @year, month: @month, user_id: @user.id).asc.pluck(:worked_in_at).map{ |item| item.strftime('%Y/%m/%d')}
     @chart_times = TimeCard.where(year: @year, month: @month, user_id: @user.id).asc.pluck(:overtime).map{ |item| Time.at(item - 32400).strftime('%X:%M').to_i}
-    @worked_time = TimeCard.where(year: @year, month: @month, user_id: @user.id).sum(:worked_time) - TimeCard.where(year: @year, month: @month, user_id: @user.id).sum(:breaked_time)
+    @worked_time = TimeCard.where(year: @year, month: @month, user_id: @user.id).sum(:worked_time)
     @overtime = TimeCard.where(year: @year, month: @month, user_id: @user.id).sum(:overtime)
   end
 

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,10 +1,14 @@
-%h2 Resend confirmation instructions
-= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
-  .actions
-    = f.submit "Resend confirmation instructions"
-= render "devise/shared/links"
+%h1.text-center.mt-4.col-12 Sign up
+.container.text-center.mb-5
+  .row.justify-content-around
+    .col-12.h-25.mb-4.text-center
+  = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.field
+        = f.label :email
+        = f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "form-control input-lg h-25 p-2 text-center"
+    .row.justify-content-around
+      .form-group.col-10.h-25.actions
+        = f.submit "確認メールを再送信する", class: "form-control input-lg h-25 p-4 btn-dark"
+  = render "devise/shared/links"

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,4 +1,6 @@
-%p="Welcome #{@email}さん!"
-%p 池田の勤怠管理アプリに登録いたしました。
+%p="Welcome #{User.find_by(email: @resource.email).name}さん!"
+%p 池田の勤怠管理アプリの新規登録または更新をいたしました。
 %p 下記確認リンクをクリックすると登録完了となります。
 %p= link_to '登録確認リンク', confirmation_url(@resource, confirmation_token: @token)
+
+%p サイト運営

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,6 +1,8 @@
-%p
-  Hello #{@resource.email}!
-%p Someone has requested a link to change your password. You can do this through the link below.
-%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
-%p If you didn't request this, please ignore this email.
-%p Your password won't change until you access the link above and create a new one.
+%p="#{User.find_by(email: @resource.email).name}様"
+%p="登録メールアドレス：#{@resource.email}"
+%p パスワードの再設定を行います。以下のURLより設定を行なってください。
+%p=link_to 'パスワード再設定', edit_password_url(@resource, reset_password_token: @token)
+%p このメールに心当たりが無い場合や、パスワード変更するのをやめる場合は何もする必要はございません。
+%p 上記URLで設定を完了するまで、パスワードは変更されません。
+
+%p サイト運営

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,19 +1,21 @@
-%h2 Change your password
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  = f.hidden_field :reset_password_token
-  .field
-    = f.label :password, "New password"
-    %br/
-    - if @minimum_password_length
-      %em
-        (#{@minimum_password_length} characters minimum)
-      %br/
-    = f.password_field :password, autofocus: true, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation, "Confirm new password"
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .actions
-    = f.submit "Change my password"
-= render "devise/shared/links"
+%h1.text-center.mt-4.col-12 パスワードの変更
+.container.text-center.mb-5
+  .row.justify-content-around
+    .col-12.h-25.mb-4.text-center
+  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    = f.hidden_field :reset_password_token
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.field
+        = f.label :password, "新規パスワード"
+        - if @minimum_password_length
+          %em（半角英数#{@minimum_password_length}文字以上）
+        = f.password_field :password, autofocus: true, autocomplete: "new-password", class: "form-control input-lg h-25 p-2 text-center"
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.field
+        = f.label :password_confirmation, "新規パスワード確認"
+        = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control input-lg h-25 p-2 text-center"
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.actions
+        = f.submit "パスワードを変更する",class: "form-control input-lg h-25 p-4 btn-dark"
+  = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,10 +1,14 @@
-%h2 Forgot your password?
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .actions
-    = f.submit "Send me reset password instructions"
-= render "devise/shared/links"
+%h1.text-center.mt-4.col-12 パスワードをお忘れですか？
+.container.text-center.mb-5
+  .row.justify-content-around
+    .col-12.h-25.mb-4.text-center
+  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+    = render "devise/shared/error_messages", resource: resource
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.field
+        = f.label :email
+        = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control input-lg h-25 p-2 text-center"
+    .row.justify-content-around
+      .form-group.col-10.h-25.actions
+        = f.submit "パスワードリセットメールを送信する", class: "form-control input-lg h-25 p-4 btn-dark"
+  = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,7 +2,6 @@
 .container.text-center.mb-5
   .row.justify-content-around
     .col-12.h-25.mb-4.text-center
-
   = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
     -if @user.errors.any?
       #error_explanation
@@ -38,5 +37,5 @@
         = f.label :admin
         = f.select :admin, [["一般", false],["管理者", true]], { selected: 1 }, class: "form-control input-lg h-25 p-2"
     .row.justify-content-around
-      .form-group.col-6.h-25.action
+      .form-group.col-6.h-25.actions
         = f.submit class: "form-control input-lg h-25 p-4 btn-dark"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,12 +1,19 @@
 %h1.text-center.mt-4.mb-4.col-12 Log in
-.form-horizontal
+.container.text-center.mb-5
+  .row.justify-content-around
+    .col-12.h-25.mb-4.text-center
   = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-    .form-group.text-center
-      .col-12.mb-5
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.field
         = f.label :email
         = f.email_field :email, class: "form-control input-lg h-25 p-2 text-center"
-      .col-12.mb-5
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.field
         = f.label :password
         = f.password_field :password, class: "form-control input-lg h-25 p-2 text-center"
-      .col-12
+    .row.justify-content-around
+      .form-group.col-10.h-25.mb-3.text-center.field
         = f.submit "Log in",class: "form-control input-lg h-25 p-4 btn-dark"
+    .row.justify-content-around
+      .form-group.col-10.h-25.actions
+  = render "devise/shared/links"

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,19 +1,8 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
-  %br/
-- if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  = link_to "Log in", new_session_path(resource_name), class: 'col-4'
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
+  = link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: 'col-4'
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
-  %br/
-- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
-  %br/
-- if devise_mapping.omniauthable?
-  - resource_class.omniauth_providers.each do |provider|
-    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
-    %br/
+  = link_to "確認メールが届きませんか？", new_confirmation_path(resource_name), class: 'col-4'

--- a/app/views/time_cards/index.html.haml
+++ b/app/views/time_cards/index.html.haml
@@ -22,15 +22,15 @@
         %td= time_str(@time_cards[index].breaked_in_at)
         %td= time_str(@time_cards[index].breaked_out_at)
         -if @time_cards[index].worked_out_at.present?
-          - min = (@time_cards[index].worked_time - @time_cards[index].breaked_time)
+          - min = (@time_cards[index].worked_time)
           -if min < 0
             %td= "00:00"
             %td= "00:00"
           -elsif min >= 0 && min < 3600
-            %td= "00:#{int_to_time(@time_cards[index].worked_time - @time_cards[index].breaked_time)}"
+            %td= "00:#{int_to_time(@time_cards[index].worked_time)}"
             %td= "00:00"
           -else
-            %td= "#{int_to_hour(@time_cards[index].worked_time) - int_to_hour(@time_cards[index].breaked_time)}:#{int_to_time(@time_cards[index].worked_time - @time_cards[index].breaked_time)}"
+            %td= "#{int_to_hour(@time_cards[index].worked_time)}:#{int_to_time(@time_cards[index].worked_time)}"
             %td= "#{int_to_hour(@time_cards[index].overtime)}:#{int_to_time(@time_cards[index].overtime)}"
         -else
           %td

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -12,7 +12,6 @@
       - @user.errors.full_messages.each do |msg|
         %li.mb-3
           = msg
-
     .row.justify-content-around
       .form-group.col-10.h-25.mb-3.text-center
         = f.label :name

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -7,6 +7,7 @@
       %td メールアドレス
       %td 権限
       %td 所属
+      %td 詳細
       %td 編集
       %td 削除
   %tbody
@@ -21,5 +22,6 @@
         - else
           一般ユーザー
       %td= f.affiliation.name
+      %td= link_to '詳細', user_path(f)
       %td= link_to '編集', edit_user_path(f)
       %td= link_to '削除', f, method: :delete, data: { confirm: t('.delete_confirm') }

--- a/db/seeds/02_user.rb
+++ b/db/seeds/02_user.rb
@@ -3,7 +3,7 @@
 1.times do |i|
   User.create!(
     name: "admin",
-    email: "admin@a.com",
+    email: "testdikd@gmail.com",
     password: "hogehoge",
     admin: true,
     affiliation_id: 1,

--- a/db/seeds/02_user.rb
+++ b/db/seeds/02_user.rb
@@ -10,7 +10,7 @@
     )
 end
 
-19.times do |i|
+5.times do |i|
   User.create!(
     name: "normal",
     email: "normal-#{i + 1}@a.com",

--- a/db/seeds/03_timecard.rb
+++ b/db/seeds/03_timecard.rb
@@ -17,7 +17,7 @@ end
 
 5.times do |i|
   TimeCard.create!(
-    affiliation_id: 2,
+    affiliation_id: 1,
     user_id: 2,
     year: 2020,
     month: 3,
@@ -34,7 +34,7 @@ end
 
 5.times do |i|
   TimeCard.create!(
-    affiliation_id: 3,
+    affiliation_id: 1,
     user_id: 2,
     year: 2020,
     month: 3,
@@ -51,7 +51,7 @@ end
 
 5.times do |i|
   TimeCard.create!(
-    affiliation_id: 4,
+    affiliation_id: 3,
     user_id: 3,
     year: 2020,
     month: 3,
@@ -68,8 +68,8 @@ end
 
 5.times do |i|
   TimeCard.create!(
-    affiliation_id: 5,
-    user_id: 4,
+    affiliation_id: 4,
+    user_id: 5,
     year: 2020,
     month: 3,
     day: 6 + i,


### PR DESCRIPTION
- [x] ユーザー一覧に詳細リンク付与

- [x] ログイン画面かから
  - [x] パスワード忘れた際の再設定用リンク　※ページのデザインも
  - [x] 確認メールの再送信リンク　※ページのデザインも

- [x] ユーザー情報編集画面
  - [x] 管理者自身を編集するとログアウトしてしまう不具合の解消
  ※あるいは管理者自身の編集は別管理者からのみにする

- [x] 確認メールの文面
  - [x] 内容修正

- [x] seedデータ修正